### PR TITLE
fix(debian): remove prerm process cleanup

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+distiller-sdk (3.4.1) stable; urgency=medium
+
+  * fix(debian): remove prerm process cleanup to avoid terminating
+    distiller-update and unrelated Python processes during SDK upgrades
+
+ -- PamirAI Incorporated <founders@pamir.ai>  Tue, 14 Apr 2026 23:18:53 -0700
+
 distiller-sdk (3.4.0) stable; urgency=medium
 
   [ utsavbalar1231 ]

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,47 +1,8 @@
 #!/bin/sh
 set -e
 
-find_sdk_python_pids() {
-	for proc_dir in /proc/[0-9]*; do
-		pid=${proc_dir##*/}
-
-		[ "$pid" = "$$" ] && continue
-
-		cmdline_file="$proc_dir/cmdline"
-		if [ -r "$cmdline_file" ]; then
-			cmdline=$(tr '\0' ' ' < "$cmdline_file" 2>/dev/null || true)
-			case "$cmdline" in
-			*"/opt/distiller-sdk/.venv/"*)
-				printf '%s\n' "$pid"
-				continue
-				;;
-			esac
-		fi
-
-		# Virtualenv entrypoints may exec as plain "python", so also honor the
-		# environment marker instead of matching the shared system interpreter inode.
-		environ_file="$proc_dir/environ"
-		if [ -r "$environ_file" ] &&
-			tr '\0' '\n' < "$environ_file" 2>/dev/null | grep -qx 'VIRTUAL_ENV=/opt/distiller-sdk/.venv'; then
-			printf '%s\n' "$pid"
-		fi
-	done
-}
-
 case "$1" in
-remove | upgrade | deconfigure)
-	# Stop any running Python processes from the SDK's virtual environment
-	if [ -d "/opt/distiller-sdk/.venv" ]; then
-		PIDS=$(find_sdk_python_pids)
-		if [ -n "$PIDS" ]; then
-			echo "INFO: Stopping SDK Python processes..."
-			for pid in $PIDS; do
-				kill -TERM "$pid" 2>/dev/null || true
-			done
-			sleep 2
-		fi
-	fi
-	;;
+remove | upgrade | deconfigure) ;;
 
 failed-upgrade) ;;
 

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,20 +1,44 @@
 #!/bin/sh
 set -e
 
+find_sdk_python_pids() {
+	for proc_dir in /proc/[0-9]*; do
+		pid=${proc_dir##*/}
+
+		[ "$pid" = "$$" ] && continue
+
+		cmdline_file="$proc_dir/cmdline"
+		if [ -r "$cmdline_file" ]; then
+			cmdline=$(tr '\0' ' ' < "$cmdline_file" 2>/dev/null || true)
+			case "$cmdline" in
+			*"/opt/distiller-sdk/.venv/"*)
+				printf '%s\n' "$pid"
+				continue
+				;;
+			esac
+		fi
+
+		# Virtualenv entrypoints may exec as plain "python", so also honor the
+		# environment marker instead of matching the shared system interpreter inode.
+		environ_file="$proc_dir/environ"
+		if [ -r "$environ_file" ] &&
+			tr '\0' '\n' < "$environ_file" 2>/dev/null | grep -qx 'VIRTUAL_ENV=/opt/distiller-sdk/.venv'; then
+			printf '%s\n' "$pid"
+		fi
+	done
+}
+
 case "$1" in
 remove | upgrade | deconfigure)
 	# Stop any running Python processes from the SDK's virtual environment
 	if [ -d "/opt/distiller-sdk/.venv" ]; then
-		VENV_PYTHON="/opt/distiller-sdk/.venv/bin/python"
-		if [ -f "$VENV_PYTHON" ]; then
-			PIDS=$(lsof -t "$VENV_PYTHON" 2>/dev/null || true)
-			if [ -n "$PIDS" ]; then
-				echo "INFO: Stopping SDK Python processes..."
-				for pid in $PIDS; do
-					kill -TERM "$pid" 2>/dev/null || true
-				done
-				sleep 2
-			fi
+		PIDS=$(find_sdk_python_pids)
+		if [ -n "$PIDS" ]; then
+			echo "INFO: Stopping SDK Python processes..."
+			for pid in $PIDS; do
+				kill -TERM "$pid" 2>/dev/null || true
+			done
+			sleep 2
 		fi
 	fi
 	;;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=61", "wheel" ]
 
 [project]
 name = "distiller-sdk"
-version = "3.4.0"
+version = "3.4.1"
 readme = "README.md"
 authors = [
   { name = "PamirAI Incorporated", email = "support@pamir.ai" },


### PR DESCRIPTION
## Summary

This change removes the `distiller-sdk` `debian/prerm` Python process cleanup entirely.

Refs #2.

## Why

The previous cleanup logic in `prerm` used interpreter-based matching to terminate SDK Python processes during upgrade. On deployed devices, that path can resolve through the shared system Python binary and sweep up unrelated processes, including `distiller-update` itself.

The first pass on this PR narrowed the process match, but review feedback was to remove the cleanup path entirely rather than keep maintainer-script process killing in place.

## What Changed

- Removed the Python process cleanup block from `debian/prerm`
- Left `prerm` as a no-op for `remove | upgrade | deconfigure`

## Impact

- Prevents `distiller-update` from being terminated during `distiller-sdk` reinstall or upgrade
- Avoids collateral SIGTERM to unrelated Python processes on the device
- Removes maintainer-script-managed SDK process killing from the package upgrade path

## Validation

- `sh -n debian/prerm`
- Verified the updated `prerm` script is syntactically valid and now performs no interpreter/process matching during upgrade
